### PR TITLE
Initial function export macro

### DIFF
--- a/src/Precompiled.hpp
+++ b/src/Precompiled.hpp
@@ -42,3 +42,9 @@
 
 // Time utilities
 #include "Time/Timer.hpp" // Scope-based timer
+
+#ifdef WIN32
+#define ADM_EXPORT __declspec(dllexport)
+#else
+#error "Don't know how to do this one yet"
+#endif


### PR DESCRIPTION
Ah, so it turns out I SHOULD open PRs for submodules too. Wish it was more automatic, but oh well!

But yeah, we gotta add different ones for MSVC, GCC and Clang I think~
Right now I'm ifdef-ing WIN32 which I probably shouldn't, and I should check the MSVC version instead. Also there's nothing for Linux. Gotta work on that too.